### PR TITLE
Some extra stuff I did: Add MIDI + DOM nodes coordinates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2682,10 +2682,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "prettier-package-json": "^2.0.1",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }

--- a/src/shaderpen.js
+++ b/src/shaderpen.js
@@ -216,12 +216,8 @@ export default class ShaderPen {
     // Check that the user requested it
     if (!this.options || !this.options.midiBindings) return;
 
-    // Check browser support
-    if (!navigator.requestMIDIAccess) {
-      console.log('WebMIDI is not supported in this browser.');
-      return;
-    }
-
+    // Setup the MIDI variables even if MIDI isn't suppported, so that the shader
+    // does not crash on other browsers and that MIDI variables have a default value.
     // Reverse mapping for quick lookup
     this.midiList = {};
     const bindings = this.options.midiBindings;
@@ -243,6 +239,13 @@ export default class ShaderPen {
         value: defaultValue,
       };
       this.midiList[messageKey] = bindingOptions;
+    }
+
+    
+    // Check browser support
+    if (!navigator.requestMIDIAccess) {
+      console.log('WebMIDI is not supported in this browser.');
+      return;
     }
 
     const onMIDISuccess = midiAccess => {


### PR DESCRIPTION
Hi! 
First thanks for this nice library, it helped me get started super fast :)

I've extended it a bit for my own usage, so this isn't really a PR, but more a place to discuss / let people know this exists / give you some ideas on extension possibilities. Most of this is probably out of the scope of the library anyway :)

I've added an `options` object to the constructor. It can be used like this: 

### **MIDI controls**
Enable the use of MIDI controllers to control shader uniforms.
```js
new Shaderpen(`
        // shader code...
    `,
    undefined,
    {
        midiBindings: [
            // MIDI messages matching command 176 and note 48 will be 
            // made available as a shader uniform float 'MIDI1'
            // from 0.0 to 1.0 with initial value 1.0
            [176, 48],

            // This one as  'MIDI2' from 0.0 to 10.0 with initial value 0.8
            [176, 49, { from: 0, to: 10, initial: 0.8 }],

            // 'MIDI3', etc...
            [176, 50],

            // ... any MIDI command/note combo
        ]
    }
)
```

That makes fiddling with shaders super fast, especially if you have a live-reload setup as there's no need to to even focus the browser window to edit shader variables :)  

### **DOM nodes rect**
```js
domBindings: [{ elem: document.getElementById("hello") }],
```
Elements passed to the `options.domBindings` are made available as shader variables too: 
```
DOM1_left
DOM1_right
DOM1_bottom
DOM1_top
DOM1_width
DOM1_height
```
(assuming the shader is taking the full page)


### **Custom canvas element**
I needed my canvas element somewhere else so I added this optional `options.canvas` to provide my own rather than create one:
```js
canvas: document.getElementById("background")
```



All of this is very much targeted at my needs, so it might not be quite suitable for a library. Feel free to reject the PR!